### PR TITLE
feat: adiciona suporte para logging em stdout e streams personalizados

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.swp
 *.swo
 .vscode
+any-stream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Todas as alterações relevantes para este projeto serão documentadas neste arq
 
 O formato segue o padrão [Keep a Changelog](http://keepachangelog.com/) e este projeto adere a [Versionamento Semântico](http://semver.org/).
 
+## [1.4.0] - 2024-12-15
+### Adicionado
+- **Suporte para logging em stdout e streams personalizados**:
+  - Modificada a classe `SuperlogSettings` para aceitar `stdout` ou uma string como stream.
+  - Atualizada a lógica de `getStream` para lidar com streams personalizados e `stdout`.
+  - Adicionados testes cobrindo cenários de logging em `stdout` e recursos personalizados.
+  - Atualizado o `.gitignore` para incluir arquivos relacionados a streams. (#e6e6455)
+
+---
+
 ## [1.3.0] - 2024-12-13
 ### Adicionado
 - **Cobertura de código no workflow de testes**:

--- a/src/SuperlogSettings.php
+++ b/src/SuperlogSettings.php
@@ -43,9 +43,9 @@ final class SuperlogSettings
     /**
      * The stream resource for the logger.
      *
-     * @var resource
+     * @var resource|string
      */
-    private static $stream;
+    private static $stream = 'stdout';
 
     /**
      * Set the log level.
@@ -114,17 +114,25 @@ final class SuperlogSettings
     /**
      * Get the stream resource
      *
-     * @return resource
+     * @return resource|string
      */
     public static function getStream()
     {
+        if (is_resource(self::$stream)) {
+            return self::$stream;
+        }
+
+        if (self::$stream === 'stdout') {
+            return 'php://stdout';
+        }
+
         return self::$stream;
     }
 
     /**
      * Set the stream resource
      *
-     * @param  resource  $stream
+     * @param  resource|string  $stream
      */
     public static function setStream($stream): void
     {
@@ -185,7 +193,7 @@ final class SuperlogSettings
             throw new RuntimeException('Environment not set');
         }
 
-        if (! is_resource(self::$stream)) {
+        if (! is_resource(self::$stream) && ! is_string(self::$stream)) {
             throw new RuntimeException('Stream not set or invalid');
         }
     }

--- a/tests/Feature.php
+++ b/tests/Feature.php
@@ -974,3 +974,97 @@ describe('raw', function () use ($logInMemory): void {
         expect($jsonOutput)->toHaveKeys(['timestamp', 'level', 'channel', 'application', 'environment', 'message', 'tags']);
     });
 });
+
+describe('log in stdout', function (): void {
+    it('logs with critical level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('stdout');
+
+        expect(fn () => Superlog::critical('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('logs with error level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('stdout');
+
+        expect(fn () => Superlog::error('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('logs with warning level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('stdout');
+
+        expect(fn () => Superlog::warning('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('logs with info level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('stdout');
+
+        expect(fn () => Superlog::info('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('logs with debug level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('stdout');
+
+        expect(fn () => Superlog::debug('foo'))->not->toThrow(Exception::class);
+    });
+});
+
+describe('log in any-stream', function (): void {
+    it('logs with critical level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('any-stream');
+
+        expect(fn () => Superlog::critical('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('logs with error level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('any-stream');
+
+        expect(fn () => Superlog::error('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('logs with warning level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('any-stream');
+
+        expect(fn () => Superlog::warning('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('logs with info level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('any-stream');
+
+        expect(fn () => Superlog::info('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('logs with debug level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('any-stream');
+
+        expect(fn () => Superlog::debug('foo'))->not->toThrow(Exception::class);
+    });
+});


### PR DESCRIPTION
- Modifica SuperlogSettings para aceitar 'stdout' ou uma string como stream
- Atualiza a lógica de getStream para lidar com 'stdout' e recursos
- Adiciona testes para logging em stdout e streams personalizados
- Atualiza .gitignore para incluir 'any-stream'