### PR TITLE
feat: adiciona opção para desabilitar o logger

### DIFF
--- a/src/Superlog.php
+++ b/src/Superlog.php
@@ -41,6 +41,10 @@ class Superlog implements LoggerContract
      */
     public static function critical(string|array $message, array $tags = []): void
     {
+        if (SuperlogSettings::isDisabled()) {
+            return;
+        }
+
         $logData = SuperlogData::from(
             message: $message,
             tags: $tags,
@@ -58,6 +62,10 @@ class Superlog implements LoggerContract
      */
     public static function error(string|array $message, array $tags = []): void
     {
+        if (SuperlogSettings::isDisabled()) {
+            return;
+        }
+
         $allowedLevels = ['debug', 'info', 'warning', __FUNCTION__];
         if (! in_array(SuperlogSettings::getLogLevel(), $allowedLevels)) {
             return;
@@ -80,6 +88,10 @@ class Superlog implements LoggerContract
      */
     public static function warning(string|array $message, array $tags = []): void
     {
+        if (SuperlogSettings::isDisabled()) {
+            return;
+        }
+
         $allowedLevels = ['debug', 'info', __FUNCTION__];
         if (! in_array(SuperlogSettings::getLogLevel(), $allowedLevels)) {
             return;
@@ -102,6 +114,10 @@ class Superlog implements LoggerContract
      */
     public static function info(string|array $message, array $tags = []): void
     {
+        if (SuperlogSettings::isDisabled()) {
+            return;
+        }
+
         $allowedLevels = ['debug', __FUNCTION__];
         if (! in_array(SuperlogSettings::getLogLevel(), $allowedLevels)) {
             return;
@@ -124,6 +140,10 @@ class Superlog implements LoggerContract
      */
     public static function debug(string|array $message, array $tags = []): void
     {
+        if (SuperlogSettings::isDisabled()) {
+            return;
+        }
+
         $allowedLevels = [__FUNCTION__];
         if (! in_array(SuperlogSettings::getLogLevel(), $allowedLevels)) {
             return;
@@ -146,6 +166,10 @@ class Superlog implements LoggerContract
      */
     public static function raw(string $level, string|array $message, array $tags = []): void
     {
+        if (SuperlogSettings::isDisabled()) {
+            return;
+        }
+
         match ($level) {
             'error' => self::error($message, $tags),
             'warning' => self::warning($message, $tags),

--- a/src/SuperlogSettings.php
+++ b/src/SuperlogSettings.php
@@ -34,6 +34,11 @@ final class SuperlogSettings
     private static string $environment = '';
 
     /**
+     * Indicates if the logger is disabled.
+     */
+    private static bool $disabled = false;
+
+    /**
      * Observers for the logger.
      *
      * @var array<LoggerObserverContract>
@@ -214,5 +219,21 @@ final class SuperlogSettings
     public static function getObservers(): array
     {
         return self::$observers;
+    }
+
+    /**
+     * Disable the logger when the give expression is true
+     */
+    public static function disableWhen(bool $disabled): void
+    {
+        self::$disabled = $disabled;
+    }
+
+    /**
+     * Check if the logger is disabled.
+     */
+    public static function isDisabled(): bool
+    {
+        return self::$disabled;
     }
 }

--- a/tests/Feature.php
+++ b/tests/Feature.php
@@ -1068,3 +1068,65 @@ describe('log in any-stream', function (): void {
         expect(fn () => Superlog::debug('foo'))->not->toThrow(Exception::class);
     });
 });
+
+describe('disabled', function (): void {
+    it('should not log when disabled with critical level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('any-stream');
+        SuperlogSettings::disableWhen(true);
+
+        expect(fn () => Superlog::critical('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('should not log when disabled with error level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('any-stream');
+        SuperlogSettings::disableWhen(true);
+
+        expect(fn () => Superlog::error('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('should not log when disabled with warning level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('any-stream');
+        SuperlogSettings::disableWhen(true);
+
+        expect(fn () => Superlog::warning('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('should not log when disabled with info level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('any-stream');
+        SuperlogSettings::disableWhen(true);
+
+        expect(fn () => Superlog::info('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('should not log when disabled with debug level', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('any-stream');
+        SuperlogSettings::disableWhen(true);
+
+        expect(fn () => Superlog::debug('foo'))->not->toThrow(Exception::class);
+    });
+
+    it('should not log when disabled with raw method', function (): void {
+        SuperlogSettings::setApplication('application');
+        SuperlogSettings::setEnvironment('testing');
+        SuperlogSettings::setChannel('channel');
+        SuperlogSettings::setStream('any-stream');
+        SuperlogSettings::disableWhen(true);
+
+        expect(fn () => Superlog::raw('info', 'foo'))->not->toThrow(Exception::class);
+    });
+});


### PR DESCRIPTION
- Implementa método `disableWhen` em `SuperlogSettings` para desativar o logger
- Adiciona verificação `isDisabled` em todos os métodos de log
- Inclui testes para garantir que nenhum log seja gerado quando desabilitado